### PR TITLE
Fix code search modal and rootSource visibility

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -69,7 +69,9 @@ async function searchUMLS() {
   tableHead.innerHTML = `<tr>
         <th>UI</th>
         <th>Name</th>
-        <th id="root-source-header" style="display: none;">Root Source</th>
+        <th id="root-source-header"${
+          returnIdType === "code" ? "" : " style=\"display: none;\""
+        }>Root Source</th>
     </tr>`;
   infoTableBody.innerHTML = '<tr><td colspan="3">No information yet...</td></tr>';
 
@@ -188,7 +190,6 @@ function openCuiOptionsModal(ui, sab, name, uri) {
 }
 
 function closeCuiOptionsModal() {
-  modalCurrentData = { ui: null, sab: null, name: null, uri: null };
   document.getElementById("selected-cui").textContent = "";
   document.getElementById("modal-backdrop").style.display = "none";
   document.getElementById("cui-options-modal").style.display = "none";


### PR DESCRIPTION
## Summary
- ensure rootSource column shows when searching by code
- preserve modal data when closing options modal
- rely on concept name if no `relatedFromIdName`

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686692ea8dd083278179c86806152c79