### PR TITLE
Update UI with dropdown menu and restore searches on back

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -177,36 +177,25 @@ pre {
   box-sizing: border-box;
 }
 
-/* Modal */
-#modal-backdrop {
-  display: none;
-  position: fixed;
-  top: 0;
-  left: 0;
-  width: 100%;
-  height: 100%;
-  background: rgba(0, 0, 0, 0.5);
-  z-index: 9998;
-}
-
-#cui-options-modal {
-  display: none;
-  position: fixed;
-  top: 25%;
-  left: 50%;
-  transform: translateX(-50%);
+/* Dropdown Menu */
+.dropdown {
+  position: absolute;
   background: #fff;
-  border: 2px solid #aaa;
-  padding: 20px;
-  z-index: 9999;
+  border: 1px solid #aaa;
+  padding: 10px;
+  z-index: 1000;
   box-shadow: 0 2px 5px rgba(0, 0, 0, 0.4);
 }
 
-#cui-options-modal h3 {
-  margin-top: 0;
+.dropdown.hidden {
+  display: none;
 }
 
-#cui-options-modal .umls-app__button {
+.hidden {
+  display: none !important;
+}
+
+#cui-options-dropdown .umls-app__button {
   width: auto;
   margin-right: 10px;
 }

--- a/umls-api-interactive.html
+++ b/umls-api-interactive.html
@@ -8,14 +8,10 @@
 </head>
 <body>
 <div class="umls-app">
-    <div id="modal-backdrop"></div>
-    <div id="cui-options-modal">
-        <h3>Select an action for <span id="selected-cui">CUI</span></h3>
-        <button class="umls-app__button" onclick="fetchConceptDetails(modalCurrentCUI, 'atoms')">Atoms</button>
-        <button class="umls-app__button" onclick="fetchConceptDetails(modalCurrentCUI, 'relations')">Relations</button>
-        <button class="umls-app__button" onclick="fetchConceptDetails(modalCurrentCUI, 'definitions')">Definitions</button>
-        <hr>
-        <button class="umls-app__button" onclick="closeCuiOptionsModal()">Close</button>
+    <div id="cui-options-dropdown" class="dropdown hidden">
+        <button class="umls-app__button" onclick="fetchConceptDetails(modalCurrentData.ui, 'atoms'); closeDropdown();">Atoms</button>
+        <button class="umls-app__button" onclick="fetchConceptDetails(modalCurrentData.ui, 'relations'); closeDropdown();">Relations</button>
+        <button class="umls-app__button" onclick="fetchConceptDetails(modalCurrentData.ui, 'definitions'); closeDropdown();">Definitions</button>
     </div>
 
     <div class="umls-app__container two-column">


### PR DESCRIPTION
## Summary
- replace modal with a small dropdown menu
- show search parameters without URL encoding
- rerun searches when loading or using browser back

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_6866960290248327a20d8a023570368b