### PR TITLE
Update results layout and search styles

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -126,11 +126,12 @@ pre {
   background: #f9f9f9;
   border: 1px solid #ddd;
   border-radius: 4px;
-  display: grid;
-  grid-template-columns: 1fr 1fr;
-  gap: 1rem;
   width: 100%;
   box-sizing: border-box;
+}
+
+.raw-data-details {
+  margin-bottom: 1rem;
 }
 
 
@@ -169,12 +170,14 @@ pre {
 
 .column-right {
   margin: 0;
-  padding: 0;
+  padding: 1rem;
   display: flex;
   flex-direction: column;
   gap: 0.5rem;
   width: 100%;
   box-sizing: border-box;
+  border: 1px solid #ccc;
+  border-radius: 4px;
 }
 
 /* Dropdown Menu */
@@ -207,6 +210,9 @@ pre {
   grid-template-columns: auto 1fr;
   align-items: center;
   gap: 0.5rem 1rem;
+  padding: 1rem;
+  border: 1px solid #ccc;
+  border-radius: 4px;
 }
 
 /* only inputs and selects go into col 2 */
@@ -266,12 +272,8 @@ pre {
 }
 
 /* Responsive adjustments */
-@media (max-width: 600px) {
-  .umls-app__container.two-column {
-    grid-template-columns: 1fr;
+  @media (max-width: 600px) {
+    .umls-app__container.two-column {
+      grid-template-columns: 1fr;
+    }
   }
-
-  .umls-app__results {
-    grid-template-columns: 1fr;
-  }
-}

--- a/umls-api-interactive.html
+++ b/umls-api-interactive.html
@@ -56,27 +56,24 @@
 
     <!-- Results displayed full width below -->
     <div class="umls-app__results" id="results">
-        <div class="umls-app__results-column">
-            <h3>Raw Data</h3>
+        <details id="raw-data-details" class="raw-data-details">
+            <summary>Raw Data</summary>
             <pre id="output">No results yet...</pre>
-        </div>
-        <div class="umls-app__results-column">
-            <h3>Information</h3>
-            <table id="info-table" class="umls-app__table">
-                <thead>
-                    <tr>
-                        <th>UI</th>
-                        <th>Name</th>
-                        <th id="root-source-header" style="display: none;">Root Source</th>
-                    </tr>
-                </thead>
-                <tbody>
-                    <tr>
-                        <td colspan="3">No information yet...</td>
-                    </tr>
-                </tbody>
-            </table>
-        </div>
+        </details>
+        <table id="info-table" class="umls-app__table">
+            <thead>
+                <tr>
+                    <th>UI</th>
+                    <th>Name</th>
+                    <th id="root-source-header" style="display: none;">Root Source</th>
+                </tr>
+            </thead>
+            <tbody>
+                <tr>
+                    <td colspan="3">No information yet...</td>
+                </tr>
+            </tbody>
+        </table>
     </div>
 </div>
 <script src="assets/js/script.js"></script>


### PR DESCRIPTION
## Summary
- restructure results section
- collapse raw JSON output using `<details>` element
- expand information table to full width
- style search configuration boxes with borders

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686698c2d4348327b69204b728516961