### PR TITLE
Move raw output above results and improve dropdown hint

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -128,6 +128,8 @@ pre {
   border-radius: 4px;
   width: 100%;
   box-sizing: border-box;
+  display: flex;
+  flex-direction: column;
 }
 
 .raw-data-details {

--- a/umls-api-interactive.html
+++ b/umls-api-interactive.html
@@ -60,6 +60,7 @@
             <summary>Raw Data</summary>
             <pre id="output">No results yet...</pre>
         </details>
+        <p class="help-text">Click a UI value to view atoms, definitions, or relations.</p>
         <table id="info-table" class="umls-app__table">
             <thead>
                 <tr>


### PR DESCRIPTION
## Summary
- ensure results area stacks vertically
- add a short message so users know to click the UI for more details

## Testing
- `node -v`


------
https://chatgpt.com/codex/tasks/task_e_68669b57dfcc83278704ff46e9b2a37c