### PR TITLE
Restore dropdown placement and collapse raw JSON

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -189,6 +189,10 @@ pre {
   display: none !important;
 }
 
+.raw-data-details {
+  margin-bottom: 1rem;
+}
+
 #cui-options-dropdown .umls-app__button {
   width: auto;
   margin-right: 10px;

--- a/umls-api-interactive.html
+++ b/umls-api-interactive.html
@@ -50,7 +50,10 @@
     </div>
     <!-- Results displayed full width below -->
     <div class="umls-app__results" id="results">
-        <pre id="output" class="hidden">No results yet...</pre>
+        <details id="raw-data-details" class="raw-data-details">
+            <summary>Raw Data</summary>
+            <pre id="output">No results yet...</pre>
+        </details>
         <p class="help-text">Click a UI value to view atoms, definitions, or relations.</p>
         <table id="info-table" class="umls-app__table">
             <thead>


### PR DESCRIPTION
## Summary
- collapse raw API JSON output by default
- style details section for spacing

## Testing
- `npm test` *(fails: package.json missing)*
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_6866a661a61c8327aa2e0e063bb5b1ab