### PR TITLE
Improve API key layout and add search on Enter

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -162,13 +162,26 @@ pre {
 .column-right {
   margin: 0;
   padding: 1rem;
-  display: flex;
-  flex-direction: column;
-  gap: 0.5rem;
+  display: grid;
+  grid-template-columns: auto 1fr;
+  align-items: center;
+  gap: 0.5rem 1rem;
   width: 100%;
   box-sizing: border-box;
   border: 1px solid #ccc;
   border-radius: 4px;
+}
+
+.column-right input {
+  grid-column: 2;
+}
+
+.column-right label {
+  grid-column: 1;
+}
+
+.column-right p {
+  grid-column: 1 / -1;
 }
 
 /* Dropdown Menu */

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -384,8 +384,9 @@ window.addEventListener("DOMContentLoaded", function () {
   const returnSelector = document.getElementById("return-id-type");
   const vocabContainer = document.getElementById("vocab-container");
   const rootSourceHeader = document.getElementById("root-source-header");
+  const queryInput = document.getElementById("query");
 
-  if (!returnSelector || !vocabContainer || !rootSourceHeader) return;
+  if (!returnSelector || !vocabContainer || !rootSourceHeader || !queryInput) return;
 
   // Read URL params (existing code)...
   const params = new URLSearchParams(window.location.search);
@@ -424,6 +425,13 @@ window.addEventListener("DOMContentLoaded", function () {
   // Wire up and initialize
   returnSelector.addEventListener("change", updateVocabVisibility);
   updateVocabVisibility();
+
+  queryInput.addEventListener("keydown", (e) => {
+    if (e.key === "Enter") {
+      e.preventDefault();
+      searchUMLS();
+    }
+  });
 
   if (searchString) {
     searchUMLS();


### PR DESCRIPTION
## Summary
- align API key input beside its label
- trigger search when pressing Enter in the search box

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_686bdb793bb48327bb1533a59f75a582