### PR TITLE
Add parents, children, and CUIs dropdown options

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -472,6 +472,9 @@ window.addEventListener("DOMContentLoaded", function () {
   const rootSourceHeader = document.getElementById("root-source-header");
   const queryInput = document.getElementById("query");
   const definitionsOption = document.getElementById("definitions-option");
+  const parentsOption = document.getElementById("parents-option");
+  const childrenOption = document.getElementById("children-option");
+  const cuisOption = document.getElementById("cuis-option");
 
   if (!returnSelector || !vocabContainer || !rootSourceHeader || !queryInput) return;
 
@@ -504,10 +507,16 @@ window.addEventListener("DOMContentLoaded", function () {
       vocabContainer.classList.remove("hidden");
       rootSourceHeader.style.display = "";
       if (definitionsOption) definitionsOption.classList.add("hidden");
+      if (parentsOption) parentsOption.classList.remove("hidden");
+      if (childrenOption) childrenOption.classList.remove("hidden");
+      if (cuisOption) cuisOption.classList.remove("hidden");
     } else {
       vocabContainer.classList.add("hidden");
       rootSourceHeader.style.display = "none";
       if (definitionsOption) definitionsOption.classList.remove("hidden");
+      if (parentsOption) parentsOption.classList.add("hidden");
+      if (childrenOption) childrenOption.classList.add("hidden");
+      if (cuisOption) cuisOption.classList.add("hidden");
     }
   }
 

--- a/umls-api-interactive.html
+++ b/umls-api-interactive.html
@@ -12,10 +12,13 @@
         <a href="#" class="dropdown-item" onclick="fetchConceptDetails(modalCurrentData.ui, 'atoms'); closeDropdown(); return false;">Atoms</a>
         <a href="#" class="dropdown-item" onclick="fetchConceptDetails(modalCurrentData.ui, 'relations'); closeDropdown(); return false;">Relations</a>
         <a id="definitions-option" href="#" class="dropdown-item" onclick="fetchConceptDetails(modalCurrentData.ui, 'definitions'); closeDropdown(); return false;">Definitions</a>
+        <a id="parents-option" href="#" class="dropdown-item" onclick="fetchConceptDetails(modalCurrentData.ui, 'parents'); closeDropdown(); return false;">Parents</a>
+        <a id="children-option" href="#" class="dropdown-item" onclick="fetchConceptDetails(modalCurrentData.ui, 'children'); closeDropdown(); return false;">Children</a>
+        <a id="cuis-option" href="#" class="dropdown-item" onclick="fetchConceptDetails(modalCurrentData.ui, 'cuis'); closeDropdown(); return false;">CUIs</a>
     </div>
 
     <h1>UMLS API Interactive Documentation</h1>
-    <p>This page allows you to search the UMLS API and inspect atoms, relations, and definitions for returned concepts.</p>
+    <p>This page allows you to search the UMLS API and inspect atoms, relations, definitions, and hierarchical information for returned concepts or codes.</p>
 
     <div class="umls-app__container two-column">
         <!-- Left column: search + recent -->


### PR DESCRIPTION
## Summary
- support showing hierarchy info for code search results
- add dropdown items for parents, children, and CUIs
- hide/show new options depending on return type

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686be332767c8327a001d0b90be970c8