### PR TITLE
Add documentation link for recent requests

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -112,6 +112,7 @@ async function searchUMLS() {
   const displayUrl = new URL(url);
   displayUrl.searchParams.set("apiKey", "***");
   recentRequestContainer.innerHTML = colorizeUrl(displayUrl);
+  updateDocLink(url);
 
   try {
     const response = await fetch(url, {
@@ -187,6 +188,18 @@ function colorizeUrl(urlObject) {
   return colorized;
 }
 
+function updateDocLink(urlObject) {
+  const docLink = document.getElementById("recent-doc-link");
+  if (!docLink || !urlObject) return;
+  const parts = urlObject.pathname.split("/");
+  const section = parts.length > 2 ? parts[2] : "";
+  let docUrl = "https://documentation.uts.nlm.nih.gov/rest/home.html";
+  if (section) {
+    docUrl = `https://documentation.uts.nlm.nih.gov/rest/${section}.html`;
+  }
+  docLink.href = docUrl;
+}
+
 function openCuiOptionsDropdown(ui, sab, name, uri, event) {
   if (event) {
     event.stopPropagation();
@@ -260,6 +273,7 @@ async function fetchConceptDetails(cui, detailType) {
   const displayApiUrl = new URL(apiUrlObj);
   displayApiUrl.searchParams.set("apiKey", "***");
   recentRequestContainer.innerHTML = colorizeUrl(displayApiUrl);
+  updateDocLink(apiUrlObj);
 
 
   const addressUrl = new URL(window.location.pathname, window.location.origin);
@@ -410,6 +424,7 @@ async function fetchRelatedDetail(apiUrl, relatedType, rootSource) {
   let displayUrlObj = new URL(urlObj);
   displayUrlObj.searchParams.set("apiKey", "***");
   document.getElementById("recent-request-output").innerHTML = colorizeUrl(displayUrlObj);
+  updateDocLink(urlObj);
 
   const currentUrl = new URL(window.location.pathname, window.location.origin);
   currentUrl.searchParams.set("related", relatedType);
@@ -485,6 +500,7 @@ window.addEventListener("DOMContentLoaded", function () {
 
   // Preload MRRANK data for later sorting
   loadMRRank();
+  updateDocLink(new URL("https://uts-ws.nlm.nih.gov/rest/home.html"));
 
   // Grab elements once DOM is ready
   const returnSelector = document.getElementById("return-id-type");

--- a/umls-api-interactive.html
+++ b/umls-api-interactive.html
@@ -57,6 +57,7 @@
     <div class="umls-app__recent-request" id="recent-request">
         <strong>Most Recent Request:</strong>
         <pre id="recent-request-output">No requests made yet...</pre>
+        <p>Docs: <a id="recent-doc-link" href="https://documentation.uts.nlm.nih.gov/rest/home.html" target="_blank">API Documentation</a></p>
     </div>
     <!-- Results displayed full width below -->
     <div class="umls-app__results" id="results">


### PR DESCRIPTION
## Summary
- link to relevant UMLS API docs alongside the most recent request display
- keep documentation link updated when making API requests

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d24cae2148327a9ab4b03366a5dea