### PR TITLE
Ensure dropdown links include returnIdType

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -238,6 +238,44 @@ function openCuiOptionsDropdown(ui, sab, name, uri, event) {
     modalCurrentData.sab = null;
   }
   const dropdown = document.getElementById("cui-options-dropdown");
+  const atomsLink = document.getElementById("atoms-option");
+  const relationsLink = document.getElementById("relations-option");
+  const definitionsLink = document.getElementById("definitions-option");
+  const parentsLink = document.getElementById("parents-option");
+  const childrenLink = document.getElementById("children-option");
+  const cuisLink = document.getElementById("cuis-option");
+  const apiKey = document.getElementById("api-key").value.trim();
+  const returnIdType = document.getElementById("return-id-type").value;
+
+  function buildDetailUrl(detailType) {
+    const url = new URL(window.location.pathname, window.location.origin);
+    if (apiKey) url.searchParams.set("apiKey", apiKey);
+    url.searchParams.set("detail", detailType);
+    url.searchParams.set("returnIdType", returnIdType);
+    if (returnIdType === "code") {
+      url.searchParams.set("code", stripBaseUrl(uri));
+      if (sab) url.searchParams.set("sab", sab);
+    } else {
+      url.searchParams.set("cui", ui);
+    }
+    return url.toString();
+  }
+
+  if (atomsLink) atomsLink.href = buildDetailUrl("atoms");
+  if (relationsLink) relationsLink.href = buildDetailUrl("relations");
+  if (definitionsLink) definitionsLink.href = buildDetailUrl("definitions");
+  if (parentsLink) parentsLink.href = buildDetailUrl("parents");
+  if (childrenLink) childrenLink.href = buildDetailUrl("children");
+  if (cuisLink) {
+    const url = new URL(window.location.pathname, window.location.origin);
+    if (apiKey) url.searchParams.set("apiKey", apiKey);
+    url.searchParams.set("string", ui);
+    url.searchParams.set("inputType", "sourceUi");
+    url.searchParams.set("searchType", "exact");
+    url.searchParams.set("returnIdType", "concept");
+    if (sab) url.searchParams.set("sabs", sab);
+    cuisLink.href = url.toString();
+  }
   const rect = event.currentTarget.getBoundingClientRect();
   dropdown.style.left = rect.left + window.pageXOffset + "px";
   dropdown.style.top = rect.bottom + window.pageYOffset + "px";

--- a/umls-api-interactive.html
+++ b/umls-api-interactive.html
@@ -9,8 +9,8 @@
 <body>
 <div class="umls-app">
     <div id="cui-options-dropdown" class="dropdown hidden">
-        <a href="#" class="dropdown-item" onclick="fetchConceptDetails(modalCurrentData.ui, 'atoms'); closeDropdown(); return false;">Atoms</a>
-        <a href="#" class="dropdown-item" onclick="fetchConceptDetails(modalCurrentData.ui, 'relations'); closeDropdown(); return false;">Relations</a>
+        <a id="atoms-option" href="#" class="dropdown-item" onclick="fetchConceptDetails(modalCurrentData.ui, 'atoms'); closeDropdown(); return false;">Atoms</a>
+        <a id="relations-option" href="#" class="dropdown-item" onclick="fetchConceptDetails(modalCurrentData.ui, 'relations'); closeDropdown(); return false;">Relations</a>
         <a id="definitions-option" href="#" class="dropdown-item" onclick="fetchConceptDetails(modalCurrentData.ui, 'definitions'); closeDropdown(); return false;">Definitions</a>
         <a id="parents-option" href="#" class="dropdown-item" onclick="fetchConceptDetails(modalCurrentData.ui, 'parents'); closeDropdown(); return false;">Parents</a>
         <a id="children-option" href="#" class="dropdown-item" onclick="fetchConceptDetails(modalCurrentData.ui, 'children'); closeDropdown(); return false;">Children</a>


### PR DESCRIPTION
## Summary
- include `returnIdType` parameter when building dropdown links so URLs work when opened directly

## Testing
- `npm test` *(fails: missing `package.json`)*

------
https://chatgpt.com/codex/tasks/task_e_686d2c1393dc8327949f174a4b57321a