### PR TITLE
Improve fetch error handling

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -396,6 +396,10 @@ async function fetchConceptDetails(cui, detailType) {
       method: "GET",
       headers: { Accept: "application/json" }
     });
+    if (!response.ok) {
+      const message = await response.text().catch(() => "");
+      throw new Error(`HTTP ${response.status}: ${message}`);
+    }
     const data = await response.json();
 
     resultsContainer.textContent = JSON.stringify(data, null, 2);
@@ -547,6 +551,10 @@ async function fetchRelatedDetail(apiUrl, relatedType, rootSource) {
       method: "GET",
       headers: { Accept: "application/json" }
     });
+    if (!response.ok) {
+      const message = await response.text().catch(() => "");
+      throw new Error(`HTTP ${response.status}: ${message}`);
+    }
     const data = await response.json();
     resultsContainer.textContent = JSON.stringify(data, null, 2);
     infoTableBody.innerHTML = "";


### PR DESCRIPTION
## Summary
- show HTTP status code text on failed concept and relation fetches

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d379f16c88327a37ed87fd99c71b3