### PR TITLE
Fix infinite recursion from hash updates

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -193,7 +193,10 @@ function colorizeUrl(urlObject) {
 function updateLocationHash(urlObject) {
   if (!urlObject || !urlObject.pathname) return;
   const cleanPath = urlObject.pathname.replace(/^\/rest\/?/, "");
-  window.location.hash = cleanPath ? `#${cleanPath}` : "";
+  const newUrl = new URL(window.location.href);
+  newUrl.hash = cleanPath ? cleanPath : "";
+  // replaceState avoids triggering a popstate event, preventing recursion
+  history.replaceState(history.state, "", newUrl);
 }
 
 function updateDocLink(urlObject) {


### PR DESCRIPTION
## Summary
- prevent endless `popstate` loops by rewriting `updateLocationHash`

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d3ae985bc8327ba69001368cab9ee