### PR TITLE
Stop linking ID clicks to atoms

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -111,7 +111,7 @@ async function renderSearchResults(data, returnIdType) {
         modalCurrentData.uri = null;
         modalCurrentData.returnIdType = "concept";
       }
-      fetchConceptDetails(item.ui, "atoms");
+      fetchConceptDetails(item.ui, "");
     });
     tr.appendChild(uiTd);
 
@@ -282,15 +282,26 @@ function parseHash() {
   const parts = pathPart.split("/").filter(Boolean);
   const result = {};
   if (parts[0] === "content") {
-    if (parts[2] === "source" && parts.length >= 6) {
-      result.sab = parts[3];
-      result.code = parts[4];
-      result.detail = parts[5];
-      result.returnIdType = "code";
-    } else if (parts[2] === "CUI" && parts.length >= 5) {
-      result.cui = parts[3];
-      result.detail = parts[4];
-      result.returnIdType = "concept";
+    if (parts[2] === "source") {
+      if (parts.length >= 6) {
+        result.sab = parts[3];
+        result.code = parts[4];
+        result.detail = parts[5];
+        result.returnIdType = "code";
+      } else if (parts.length === 5) {
+        result.sab = parts[3];
+        result.code = parts[4];
+        result.returnIdType = "code";
+      }
+    } else if (parts[2] === "CUI") {
+      if (parts.length >= 5) {
+        result.cui = parts[3];
+        result.detail = parts[4];
+        result.returnIdType = "concept";
+      } else if (parts.length === 4) {
+        result.cui = parts[3];
+        result.returnIdType = "concept";
+      }
     }
   }
   if (queryPart) {
@@ -308,7 +319,7 @@ function getSelectedVocabularies() {
   );
 }
 
-async function fetchConceptDetails(cui, detailType, options = {}) {
+async function fetchConceptDetails(cui, detailType = "", options = {}) {
   const { skipPushState = false } = options;
   const apiKey = document.getElementById("api-key").value.trim();
   const returnIdType = modalCurrentData.returnIdType ||
@@ -327,14 +338,14 @@ async function fetchConceptDetails(cui, detailType, options = {}) {
   let baseUrl;
   if (returnIdType === "code") {
     if (modalCurrentData.uri) {
-      baseUrl = modalCurrentData.uri + "/" + detailType;
+      baseUrl = modalCurrentData.uri + (detailType ? "/" + detailType : "");
     } else if (modalCurrentData.sab) {
-      baseUrl = `https://uts-ws.nlm.nih.gov/rest/content/current/source/${modalCurrentData.sab}/${cui}/${detailType}`;
+      baseUrl = `https://uts-ws.nlm.nih.gov/rest/content/current/source/${modalCurrentData.sab}/${cui}` + (detailType ? `/${detailType}` : "");
     } else {
-      baseUrl = `https://uts-ws.nlm.nih.gov/rest/content/current/source/${cui}/${detailType}`;
+      baseUrl = `https://uts-ws.nlm.nih.gov/rest/content/current/source/${cui}` + (detailType ? `/${detailType}` : "");
     }
   } else {
-    baseUrl = `https://uts-ws.nlm.nih.gov/rest/content/current/CUI/${cui}/${detailType}`;
+    baseUrl = `https://uts-ws.nlm.nih.gov/rest/content/current/CUI/${cui}` + (detailType ? `/${detailType}` : "");
   }
   const apiUrlObj = new URL(baseUrl);
   apiUrlObj.searchParams.append("apiKey", apiKey);
@@ -346,7 +357,11 @@ async function fetchConceptDetails(cui, detailType, options = {}) {
   updateDocLink(apiUrlObj);
 
   const addressUrl = new URL(window.location.pathname, window.location.origin);
-  addressUrl.searchParams.set("detail", detailType);
+  if (detailType) {
+    addressUrl.searchParams.set("detail", detailType);
+  } else {
+    addressUrl.searchParams.delete("detail");
+  }
   addressUrl.searchParams.set("apiKey", apiKey);
   addressUrl.searchParams.set("returnIdType", returnIdType);
   if (returnIdType === "code") {
@@ -362,9 +377,10 @@ async function fetchConceptDetails(cui, detailType, options = {}) {
   }
   updateLocationHash(apiUrlObj);
 
-  resultsContainer.textContent = `Loading ${detailType} for ${cui}...`;
-  const loadingColspan =
-    detailType === "relations" ? 5 : detailType === "definitions" ? 2 : 3;
+  resultsContainer.textContent = detailType
+    ? `Loading ${detailType} for ${cui}...`
+    : `Loading details for ${cui}...`;
+  const loadingColspan = detailType === "relations" ? 5 : detailType === "definitions" ? 2 : detailType ? 3 : 2;
   infoTableBody.innerHTML = `<tr><td colspan="${loadingColspan}">Loading...</td></tr>`;
 
   try {
@@ -382,7 +398,58 @@ async function fetchConceptDetails(cui, detailType, options = {}) {
 
     infoTableBody.innerHTML = "";
 
-    if (detailType === "atoms") {
+    if (!detailType) {
+      tableHead.innerHTML = `<tr><th>Key</th><th>Value</th></tr>`;
+      const detailObj = data && typeof data.result === "object" && !Array.isArray(data.result)
+        ? data.result
+        : data;
+      if (!detailObj || typeof detailObj !== "object") {
+        infoTableBody.innerHTML = `<tr><td colspan="2">No details found for this ${cui}.</td></tr>`;
+        return;
+      }
+      Object.keys(detailObj).forEach(key => {
+        const value = detailObj[key];
+        if (typeof value === "string" && value.toUpperCase() === "NONE") return;
+        const tr = document.createElement("tr");
+        const tdKey = document.createElement("td");
+        tdKey.textContent = key;
+        const tdValue = document.createElement("td");
+        if (typeof value === "string" && value.startsWith("http")) {
+          const link = document.createElement("a");
+          link.href = "#";
+          link.textContent = value;
+          link.addEventListener("click", function (e) {
+            e.preventDefault();
+            const atomsMatch = value.match(/\/rest\/content\/[^/]+\/source\/([^/]+)\/([^/]+)\/atoms$/);
+            const codeMatch = value.match(/\/rest\/content\/[^/]+\/source\/([^/]+)\/([^/]+)$/);
+            if (atomsMatch) {
+              modalCurrentData.sab = atomsMatch[1];
+              modalCurrentData.ui = atomsMatch[2];
+              modalCurrentData.uri = value.replace(/\/atoms$/, "");
+              modalCurrentData.returnIdType = "code";
+              fetchConceptDetails(atomsMatch[2], "");
+            } else if (codeMatch) {
+              modalCurrentData.sab = codeMatch[1];
+              modalCurrentData.ui = codeMatch[2];
+              modalCurrentData.uri = value;
+              modalCurrentData.returnIdType = "code";
+              fetchConceptDetails(codeMatch[2], "");
+            } else {
+              fetchRelatedDetail(value, key.toLowerCase());
+            }
+          });
+          tdValue.appendChild(link);
+        } else if (typeof value === "string") {
+          tdValue.textContent = value;
+        } else {
+          tdValue.textContent = JSON.stringify(value, null, 2);
+        }
+        tr.appendChild(tdKey);
+        tr.appendChild(tdValue);
+        infoTableBody.appendChild(tr);
+      });
+
+    } else if (detailType === "atoms") {
       tableHead.innerHTML = `<tr><th>Atom</th><th>Term Type</th><th>Root Source</th></tr>`;
     } else if (detailType === "definitions") {
       tableHead.innerHTML = `<tr><th>Definition</th><th>Root Source</th></tr>`;
@@ -586,13 +653,13 @@ async function fetchRelatedDetail(apiUrl, relatedType, rootSource, options = {})
             modalCurrentData.ui = atomsMatch[2];
             modalCurrentData.uri = value.replace(/\/atoms$/, "");
             modalCurrentData.returnIdType = "code";
-            fetchConceptDetails(atomsMatch[2], "atoms");
+            fetchConceptDetails(atomsMatch[2], "");
           } else if (codeMatch) {
             modalCurrentData.sab = codeMatch[1];
             modalCurrentData.ui = codeMatch[2];
             modalCurrentData.uri = value;
             modalCurrentData.returnIdType = "code";
-            fetchConceptDetails(codeMatch[2], "atoms");
+            fetchConceptDetails(codeMatch[2], "");
           } else {
             fetchRelatedDetail(value, key.toLowerCase());
           }
@@ -688,7 +755,7 @@ async function fetchCuisForCode(code, sab) {
         modalCurrentData.sab = null;
         modalCurrentData.uri = null;
         modalCurrentData.returnIdType = "concept";
-        fetchConceptDetails(item.ui, "atoms");
+        fetchConceptDetails(item.ui, "");
       });
       tr.appendChild(uiTd);
 
@@ -774,6 +841,19 @@ window.addEventListener("DOMContentLoaded", function () {
         modalCurrentData.returnIdType = "concept";
       }
       fetchConceptDetails(code || cui, detail, { skipPushState: fromPopState });
+    } else if ((returnSelector.value === "code" && code && sab) || (returnSelector.value !== "code" && cui)) {
+      if (returnSelector.value === "code") {
+        modalCurrentData.sab = sab;
+        modalCurrentData.ui = code;
+        modalCurrentData.uri = `https://uts-ws.nlm.nih.gov/rest/content/current/source/${sab}/${code}`;
+        modalCurrentData.returnIdType = "code";
+      } else {
+        modalCurrentData.sab = null;
+        modalCurrentData.ui = cui;
+        modalCurrentData.uri = null;
+        modalCurrentData.returnIdType = "concept";
+      }
+      fetchConceptDetails(code || cui, "", { skipPushState: fromPopState });
     } else if (related && relatedId) {
       let fullUrl;
       if (sab) {


### PR DESCRIPTION
## Summary
- change default click on IDs to show base info rather than `/atoms`
- handle URLs without detail segment in `parseHash`
- support empty detail in `fetchConceptDetails`
- fetch base details when the URL only specifies a code or CUI

## Testing
- `node -c assets/js/script.js`

------
https://chatgpt.com/codex/tasks/task_e_686d73667ba08327ac406cb5c0cfed5e