### PR TITLE
Remove API key from URL bar

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -150,7 +150,6 @@ async function searchUMLS(options = {}) {
 
   const newUrl = new URL(window.location.pathname, window.location.origin);
   newUrl.searchParams.set("string", searchString);
-  newUrl.searchParams.set("apiKey", apiKey);
   if (returnIdType !== "concept") {
     newUrl.searchParams.set("returnIdType", returnIdType);
   }
@@ -347,7 +346,6 @@ async function fetchConceptDetails(cui, detailType, options = {}) {
 
   const addressUrl = new URL(window.location.pathname, window.location.origin);
   addressUrl.searchParams.set("detail", detailType);
-  addressUrl.searchParams.set("apiKey", apiKey);
   addressUrl.searchParams.set("returnIdType", returnIdType);
   if (returnIdType === "code") {
     addressUrl.searchParams.set("code", stripBaseUrl(modalCurrentData.uri));
@@ -524,7 +522,6 @@ async function fetchRelatedDetail(apiUrl, relatedType, rootSource, options = {})
   const currentUrl = new URL(window.location.pathname, window.location.origin);
   currentUrl.searchParams.set("related", relatedType);
   currentUrl.searchParams.set("relatedId", stripBaseUrl(apiUrl));
-  currentUrl.searchParams.set("apiKey", apiKey);
   if (rootSource) {
     currentUrl.searchParams.set("sab", rootSource);
   }


### PR DESCRIPTION
## Summary
- avoid storing the API key in the browser address bar

## Testing
- `npm test` *(fails: Could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686d747e6f848327beaaa59c83346115