### PR TITLE
Improve concept click results

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -194,6 +194,7 @@ pre {
   margin-bottom: 1rem;
 }
 
+
 .umls-app__recent-request {
   width: 100%;
   box-sizing: border-box;

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -66,6 +66,51 @@ function sortByAdditionalRelationLabel(arr) {
     });
 }
 
+function renderConceptSummary(concept) {
+  const infoTableBody = document.querySelector("#info-table tbody");
+  if (!infoTableBody) return;
+
+  infoTableBody.querySelectorAll(".concept-summary-row").forEach((row) => row.remove());
+
+  if (!concept || typeof concept !== "object") {
+    return;
+  }
+
+  const rows = [];
+  const nameValue = concept.name
+    ? `${concept.name} (${concept.ui || ""})`
+    : concept.ui || "";
+  if (nameValue) rows.push(["Name", nameValue]);
+
+  if (Array.isArray(concept.semanticTypes) && concept.semanticTypes.length) {
+    const types = concept.semanticTypes
+      .map((t) => t.name || t.abbrev || t)
+      .join(", ");
+    rows.push(["Semantic Types", types]);
+  }
+
+  if (concept.atomCount !== undefined) {
+    rows.push(["Atom Count", concept.atomCount]);
+  }
+
+  if (concept.relationCount !== undefined) {
+    rows.push(["Relation Count", concept.relationCount]);
+  }
+
+  for (let i = rows.length - 1; i >= 0; i--) {
+    const [label, value] = rows[i];
+    const tr = document.createElement("tr");
+    tr.classList.add("concept-summary-row");
+    const tdKey = document.createElement("td");
+    tdKey.textContent = label;
+    const tdValue = document.createElement("td");
+    tdValue.textContent = value;
+    tr.appendChild(tdKey);
+    tr.appendChild(tdValue);
+    infoTableBody.prepend(tr);
+  }
+}
+
 const searchCache = {};
 
 async function renderSearchResults(data, returnIdType) {
@@ -167,6 +212,7 @@ async function searchUMLS(options = {}) {
   const tableHead = document.querySelector("#info-table thead");
   const infoTable = document.getElementById("info-table");
   const noResultsMessage = document.getElementById("no-results-message");
+  renderConceptSummary(null);
 
   resultsContainer.textContent = "Loading...";
   tableHead.innerHTML = `<tr>
@@ -380,6 +426,9 @@ async function fetchConceptDetails(cui, detailType = "", options = {}) {
   resultsContainer.textContent = detailType
     ? `Loading ${detailType} for ${cui}...`
     : `Loading details for ${cui}...`;
+  if (detailType) {
+    renderConceptSummary(null);
+  }
   const loadingColspan = detailType === "relations" ? 5 : detailType === "definitions" ? 2 : detailType ? 3 : 2;
   infoTableBody.innerHTML = `<tr><td colspan="${loadingColspan}">Loading...</td></tr>`;
 
@@ -405,8 +454,12 @@ async function fetchConceptDetails(cui, detailType = "", options = {}) {
         : data;
       if (!detailObj || typeof detailObj !== "object") {
         infoTableBody.innerHTML = `<tr><td colspan="2">No details found for this ${cui}.</td></tr>`;
+        renderConceptSummary(null);
         return;
       }
+
+      renderConceptSummary(detailObj);
+
       Object.keys(detailObj).forEach(key => {
         const value = detailObj[key];
         if (typeof value === "string" && value.toUpperCase() === "NONE") return;
@@ -416,28 +469,10 @@ async function fetchConceptDetails(cui, detailType = "", options = {}) {
         const tdValue = document.createElement("td");
         if (typeof value === "string" && value.startsWith("http")) {
           const link = document.createElement("a");
-          link.href = "#";
+          link.href = value;
+          link.target = "_blank";
+          link.rel = "noopener noreferrer";
           link.textContent = value;
-          link.addEventListener("click", function (e) {
-            e.preventDefault();
-            const atomsMatch = value.match(/\/rest\/content\/[^/]+\/source\/([^/]+)\/([^/]+)\/atoms$/);
-            const codeMatch = value.match(/\/rest\/content\/[^/]+\/source\/([^/]+)\/([^/]+)$/);
-            if (atomsMatch) {
-              modalCurrentData.sab = atomsMatch[1];
-              modalCurrentData.ui = atomsMatch[2];
-              modalCurrentData.uri = value.replace(/\/atoms$/, "");
-              modalCurrentData.returnIdType = "code";
-              fetchConceptDetails(atomsMatch[2], "");
-            } else if (codeMatch) {
-              modalCurrentData.sab = codeMatch[1];
-              modalCurrentData.ui = codeMatch[2];
-              modalCurrentData.uri = value;
-              modalCurrentData.returnIdType = "code";
-              fetchConceptDetails(codeMatch[2], "");
-            } else {
-              fetchRelatedDetail(value, key.toLowerCase());
-            }
-          });
           tdValue.appendChild(link);
         } else if (typeof value === "string") {
           tdValue.textContent = value;
@@ -642,28 +677,10 @@ async function fetchRelatedDetail(apiUrl, relatedType, rootSource, options = {})
       // Link URL values back into the app
       if (typeof value === "string" && value.startsWith("http")) {
         const link = document.createElement("a");
-        link.href = "#";
+        link.href = value;
+        link.target = "_blank";
+        link.rel = "noopener noreferrer";
         link.textContent = value;
-        link.addEventListener("click", function (e) {
-          e.preventDefault();
-          const atomsMatch = value.match(/\/rest\/content\/[^/]+\/source\/([^/]+)\/([^/]+)\/atoms$/);
-          const codeMatch = value.match(/\/rest\/content\/[^/]+\/source\/([^/]+)\/([^/]+)$/);
-          if (atomsMatch) {
-            modalCurrentData.sab = atomsMatch[1];
-            modalCurrentData.ui = atomsMatch[2];
-            modalCurrentData.uri = value.replace(/\/atoms$/, "");
-            modalCurrentData.returnIdType = "code";
-            fetchConceptDetails(atomsMatch[2], "");
-          } else if (codeMatch) {
-            modalCurrentData.sab = codeMatch[1];
-            modalCurrentData.ui = codeMatch[2];
-            modalCurrentData.uri = value;
-            modalCurrentData.returnIdType = "code";
-            fetchConceptDetails(codeMatch[2], "");
-          } else {
-            fetchRelatedDetail(value, key.toLowerCase());
-          }
-        });
         tdValue.appendChild(link);
       } else if (typeof value === "string") {
         tdValue.textContent = value;


### PR DESCRIPTION
## Summary
- show concept summary directly within the results table
- remove separate summary box styling
- show URL values as real links that open in a new tab

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_686d74cc05188327bd342c137b2e33c1