### PR TITLE
Add result headings

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -206,6 +206,11 @@ pre {
   font-size: 1.2em;
 }
 
+#results-heading {
+  margin: 0.5rem 0;
+  text-align: center;
+}
+
 .umls-app__recent-request {
   width: 100%;
   box-sizing: border-box;

--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -112,6 +112,12 @@ async function renderSearchResults(data, returnIdType) {
   const resultsContainer = document.getElementById("output");
   const infoTableBody = document.querySelector("#info-table tbody");
   const tableHead = document.querySelector("#info-table thead");
+
+  const resultsHeading = document.getElementById("results-heading");
+  if (resultsHeading) {
+    resultsHeading.textContent = "";
+    resultsHeading.classList.add("hidden");
+  }
   const infoTable = document.getElementById("info-table");
   const noResultsMessage = document.getElementById("no-results-message");
 
@@ -177,6 +183,17 @@ async function searchUMLS(options = {}) {
   const selectedVocabularies =
     returnIdType === "code" ? getSelectedVocabularies() : [];
 
+  const resultsHeading = document.getElementById("results-heading");
+  if (resultsHeading) {
+    if (searchString) {
+      resultsHeading.textContent = `Results for "${searchString}"`;
+      resultsHeading.classList.remove("hidden");
+    } else {
+      resultsHeading.textContent = "";
+      resultsHeading.classList.add("hidden");
+    }
+  }
+
   if (!apiKey || !searchString) {
     alert("Please enter both an API key and a search term.");
     return;
@@ -204,6 +221,12 @@ async function searchUMLS(options = {}) {
   const infoTableBody = document.querySelector("#info-table tbody");
   const recentRequestContainer = document.getElementById("recent-request-output");
   const tableHead = document.querySelector("#info-table thead");
+
+  const resultsHeading = document.getElementById("results-heading");
+  if (resultsHeading) {
+    resultsHeading.textContent = "";
+    resultsHeading.classList.add("hidden");
+  }
   const infoTable = document.getElementById("info-table");
   const noResultsMessage = document.getElementById("no-results-message");
   renderConceptSummary(null);
@@ -411,6 +434,11 @@ async function fetchConceptDetails(cui, detailType = "", options = {}) {
   const recentRequestContainer = document.getElementById("recent-request-output");
   const tableHead = document.querySelector("#info-table thead");
 
+  const resultsHeading = document.getElementById("results-heading");
+  if (resultsHeading) {
+    resultsHeading.textContent = "";
+    resultsHeading.classList.add("hidden");
+  }
 
   if (!apiKey) {
     alert("Please enter an API key first.");
@@ -675,6 +703,12 @@ async function fetchRelatedDetail(apiUrl, relatedType, rootSource, options = {})
   const infoTableBody = document.querySelector("#info-table tbody");
   const tableHead = document.querySelector("#info-table thead");
 
+  const resultsHeading = document.getElementById("results-heading");
+  if (resultsHeading) {
+    resultsHeading.textContent = "";
+    resultsHeading.classList.add("hidden");
+  }
+
   resultsContainer.textContent = `Loading related ${relatedType} information...`;
   infoTableBody.innerHTML = '<tr><td colspan="2">Loading...</td></tr>';
   tableHead.innerHTML = `<tr><th>Key</th><th>Value</th></tr>`;
@@ -751,6 +785,12 @@ async function fetchCuisForCode(code, sab) {
   const tableHead = document.querySelector("#info-table thead");
   const infoTable = document.getElementById("info-table");
   const noResultsMessage = document.getElementById("no-results-message");
+
+  const resultsHeading = document.getElementById("results-heading");
+  if (resultsHeading) {
+    resultsHeading.textContent = `Results for "${code}"`;
+    resultsHeading.classList.remove("hidden");
+  }
 
   const url = new URL("https://uts-ws.nlm.nih.gov/rest/search/current");
   url.searchParams.append("string", code);

--- a/umls-api-interactive.html
+++ b/umls-api-interactive.html
@@ -53,6 +53,7 @@
     </div>
     <!-- Results displayed full width below -->
     <div class="umls-app__results" id="results">
+        <h2 id="results-heading" class="hidden"></h2>
         <details id="raw-data-details" class="raw-data-details">
             <summary>Raw Data</summary>
             <pre id="output">No results yet...</pre>


### PR DESCRIPTION
## Summary
- show search input or code as a heading for results
- hide the heading when viewing concept details or related information
- tweak CSS for the new results heading element

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d809040988327b93d46a7f00b625e