### PR TITLE
Hide atom and relation counts in search results

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -109,7 +109,18 @@ async function renderSearchResults(data, returnIdType) {
   const infoTable = document.getElementById("info-table");
   const noResultsMessage = document.getElementById("no-results-message");
 
-  resultsContainer.textContent = JSON.stringify(data, null, 2);
+  let displayData = data;
+  if (data && data.result && Array.isArray(data.result.results)) {
+    displayData = JSON.parse(JSON.stringify(data));
+    displayData.result.results = displayData.result.results.map((item) => {
+      const cleaned = { ...item };
+      Object.keys(cleaned).forEach((key) => {
+        if (/^(atom|relation)count$/i.test(key)) delete cleaned[key];
+      });
+      return cleaned;
+    });
+  }
+  resultsContainer.textContent = JSON.stringify(displayData, null, 2);
   infoTableBody.innerHTML = "";
 
   const results = data.result && data.result.results ? data.result.results : [];


### PR DESCRIPTION
## Summary
- sanitize concept search JSON results
  - strip `atomCount` and `relationCount` before rendering raw output

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686e721a5fd0832785d7625428abd28f