### PR TITLE
Fix fallback from concept links in relations table

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -751,10 +751,11 @@ async function fetchConceptDetails(cui, detailType = "", options = {}) {
         col1.style.cursor = "pointer";
         col1.textContent = relation.relatedFromIdName || modalCurrentData.name || "(no relatedFromIdName)";
         col1.addEventListener("click", function () {
+          const fromId = relation.relatedFromId || modalCurrentData.ui;
           if (returnIdType === "code") {
-            fetchRelatedDetail(relation.relatedFromId, "from", relation.rootSource);
+            fetchRelatedDetail(fromId, "from", relation.rootSource);
           } else {
-            fetchRelatedDetail(relation.relatedFromId, "from");
+            fetchRelatedDetail(fromId, "from");
           }
         });
         tr.appendChild(col1);


### PR DESCRIPTION
## Summary
- ensure clicking the 'From Name' cell works even when `relatedFromId` is missing

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686e745ec7188327bf212ef05f7e6652