### PR TITLE
Add code column for atom tables

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -698,6 +698,14 @@ async function fetchConceptDetails(cui, detailType = "", options = {}) {
         tr.appendChild(col3);
         const col4 = document.createElement("td");
         col4.textContent = atom.code || "";
+        if (atom.code) {
+          col4.style.color = "blue";
+          col4.style.textDecoration = "underline";
+          col4.style.cursor = "pointer";
+          col4.addEventListener("click", () => {
+            fetchCuisForCode(atom.code, atom.rootSource);
+          });
+        }
         tr.appendChild(col4);
         infoTableBody.appendChild(tr);
       });


### PR DESCRIPTION
## Summary
- add code column when listing atoms
- make codes clickable to fetch CUIs for the source code

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e7998d3148327b559c506d87e3650