### PR TITLE
Link fallback "From Name" to concept

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -765,13 +765,18 @@ async function fetchConceptDetails(cui, detailType = "", options = {}) {
         col1.style.color = "blue";
         col1.style.textDecoration = "underline";
         col1.style.cursor = "pointer";
+        const fromNameFallback = !relation.relatedFromIdName;
         col1.textContent = relation.relatedFromIdName || modalCurrentData.name || "(no relatedFromIdName)";
         col1.addEventListener("click", function () {
-          const fromId = relation.relatedFromId || modalCurrentData.ui;
-          if (returnIdType === "code") {
-            fetchRelatedDetail(fromId, "from", relation.rootSource);
+          if (fromNameFallback) {
+            fetchConceptDetails(modalCurrentData.ui, "");
           } else {
-            fetchRelatedDetail(fromId, "from");
+            const fromId = relation.relatedFromId || modalCurrentData.ui;
+            if (returnIdType === "code") {
+              fetchRelatedDetail(fromId, "from", relation.rootSource);
+            } else {
+              fetchRelatedDetail(fromId, "from");
+            }
           }
         });
         tr.appendChild(col1);


### PR DESCRIPTION
## Summary
- detect when a relation's `From Name` is missing
- link that fallback name to the current CUI overview instead of related-from details

## Testing
- `npm test` *(fails: no such command)*

------
https://chatgpt.com/codex/tasks/task_e_686e7a123eb48327bd95c71aa8f32cd2