### PR TITLE
Fix atoms/preferred single object display

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -672,6 +672,10 @@ async function fetchConceptDetails(cui, detailType = "", options = {}) {
       detailArray = data.result.results;
     } else if (detailType && data.result && Array.isArray(data.result[detailType])) {
       detailArray = data.result[detailType];
+    } else if (data.result && typeof data.result === "object") {
+      // Some endpoints (e.g., atoms/preferred) return a single object
+      // instead of an array; normalize to an array for processing
+      detailArray = [data.result];
     }
     await loadMRRank();
     let sortedDetails = sortByMRRank(detailArray);


### PR DESCRIPTION
## Summary
- normalize single-object results (like atoms/preferred) to arrays

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686e7aef16b88327b6e3ddca27794823