### PR TITLE
Fix resultsHeading usage before initialization

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -108,6 +108,7 @@ async function renderSearchResults(data, returnIdType) {
   const resultsContainer = document.getElementById("output");
   const infoTableBody = document.querySelector("#info-table tbody");
   const tableHead = document.querySelector("#info-table thead");
+  const resultsHeading = document.getElementById("results-heading");
 
   if (resultsHeading) {
     resultsHeading.textContent = "";
@@ -190,6 +191,7 @@ async function searchUMLS(options = {}) {
   const returnIdType = document.getElementById("return-id-type").value;
   const selectedVocabularies =
     returnIdType === "code" ? getSelectedVocabularies() : [];
+  const resultsHeading = document.getElementById("results-heading");
 
   if (resultsHeading) {
     if (searchString) {
@@ -228,8 +230,6 @@ async function searchUMLS(options = {}) {
   const infoTableBody = document.querySelector("#info-table tbody");
   const recentRequestContainer = document.getElementById("recent-request-output");
   const tableHead = document.querySelector("#info-table thead");
-
-  const resultsHeading = document.getElementById("results-heading");
   if (resultsHeading) {
     resultsHeading.textContent = "";
     resultsHeading.classList.add("hidden");


### PR DESCRIPTION
## Summary
- ensure `resultsHeading` is fetched before being used
- remove duplicate declaration in `searchUMLS`

## Testing
- `grep -n "resultsHeading" -n assets/js/script.js | head`

------
https://chatgpt.com/codex/tasks/task_e_686e7cb6ec4c8327abc68939ab9da5d9