### PR TITLE
Handle code links via app navigation

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -727,10 +727,12 @@ async function fetchConceptDetails(cui, detailType = "", options = {}) {
         const col4 = document.createElement("td");
         if (atom.code) {
           const link = document.createElement("a");
-          link.href = atom.code;
-          link.target = "_blank";
-          link.rel = "noopener";
+          link.href = "#";
           link.textContent = stripBaseUrl(atom.code);
+          link.addEventListener("click", function (e) {
+            e.preventDefault();
+            navigateToUmlsUrl(atom.code, "code");
+          });
           col4.appendChild(link);
         } else {
           col4.textContent = "";


### PR DESCRIPTION
## Summary
- keep request history consistent with docs
- fetch code detail within the app instead of linking out

## Testing
- `npx eslint assets/js/script.js`

------
https://chatgpt.com/codex/tasks/task_e_686e817ad8b483279cfc287786226da9