### PR TITLE
Handle sourceUi search links

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -413,6 +413,11 @@ function parseHash() {
       }
     }
   }
+  else if (parts[0] === "search") {
+    if (parts.length >= 2) {
+      result.searchRelease = parts[1];
+    }
+  }
   if (queryPart) {
     const sp = new URLSearchParams(queryPart);
     for (const [k, v] of sp.entries()) {
@@ -1276,7 +1281,12 @@ window.addEventListener("DOMContentLoaded", function () {
     const apiKey = params.get("apiKey");
     const searchString = params.get("string");
     let returnIdType = params.get("returnIdType") || hashParams.returnIdType;
+    if (!returnIdType) {
+      returnIdType = "concept";
+    }
     const sabs = params.get("sabs") || hashParams.sabs;
+    const inputType = params.get("inputType") || hashParams.inputType;
+    const searchType = params.get("searchType") || hashParams.searchType;
     let detail = params.get("detail") || hashParams.detail;
     let cui = params.get("cui") || hashParams.cui;
     let code = params.get("code") || hashParams.code;
@@ -1356,9 +1366,14 @@ window.addEventListener("DOMContentLoaded", function () {
         fullUrl = `https://uts-ws.nlm.nih.gov/rest/content/current/CUI/${relatedId}`;
       }
       fetchRelatedDetail(fullUrl, related, sab, { skipPushState: fromPopState });
+    } else if (inputType === "sourceUi" && searchType === "exact" && searchString) {
+      if (hashParams.searchRelease) {
+        searchRelease = hashParams.searchRelease;
+      }
+      fetchCuisForCode(searchString, sab);
     } else if (searchString) {
-      searchUMLS({ skipPushState: fromPopState, useCache: fromPopState });
-  }
+      searchUMLS({ skipPushState: fromPopState, useCache: fromPopState, release: hashParams.searchRelease });
+    }
   }
 
   // Helper to toggle visibility


### PR DESCRIPTION
## Summary
- handle search links with `inputType=sourceUi`
- parse search release from URL hash
- default `returnIdType` to concept when unspecified

## Testing
- `node --check assets/js/script.js`


------
https://chatgpt.com/codex/tasks/task_e_686ea88d38f883279b7c6fca31d76612