### PR TITLE
Align results container layout

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -122,7 +122,7 @@ pre {
 
 .umls-app__results {
   margin-top: 1rem;
-  padding: 0.5rem;
+  padding: 0;
   background: #f9f9f9;
   border: 1px solid #ddd;
   border-radius: 4px;
@@ -130,6 +130,16 @@ pre {
   box-sizing: border-box;
   display: flex;
   flex-direction: column;
+}
+
+.results-inner {
+  padding: 1rem;
+}
+
+.umls-app__table {
+  margin: 0;
+  width: 100%;
+  border-collapse: collapse;
 }
 
 
@@ -190,13 +200,15 @@ pre {
   display: none !important;
 }
 
+
 .raw-data-details {
-  margin-bottom: 1rem;
+  margin: 0;
+  padding: 0;
 }
 
 .concept-summary {
-  margin: 1rem 0;
-  padding: 0.5rem 1rem;
+  margin: 0;
+  padding: 0;
   border: 1px solid #ddd;
   border-radius: 4px;
   background: #fff;
@@ -207,12 +219,14 @@ pre {
 }
 
 #results-heading {
-  margin: 0.5rem 0;
+  margin: 0;
+  padding: 0;
   text-align: center;
 }
 
 #search-summary {
-  margin: 0.5rem 0;
+  margin: 0;
+  padding: 0;
   text-align: center;
 }
 

--- a/umls-api-interactive.html
+++ b/umls-api-interactive.html
@@ -53,15 +53,16 @@
     </div>
     <!-- Results displayed full width below -->
     <div class="umls-app__results" id="results">
-        <h2 id="results-heading" class="hidden"></h2>
-        <details id="raw-data-details" class="raw-data-details">
-            <summary>Raw Data</summary>
-            <pre id="output">No results yet...</pre>
-        </details>
-        <p id="search-summary" class="search-summary hidden"></p>
-        <div id="concept-summary" class="concept-summary hidden"></div>
-        <p id="no-results-message" class="hidden">No Results</p>
-        <table id="info-table" class="umls-app__table">
+        <div class="results-inner">
+            <h2 id="results-heading" class="hidden"></h2>
+            <details id="raw-data-details" class="raw-data-details">
+                <summary>Raw Data</summary>
+                <pre id="output">No results yet...</pre>
+            </details>
+            <p id="search-summary" class="search-summary hidden"></p>
+            <div id="concept-summary" class="concept-summary hidden"></div>
+            <p id="no-results-message" class="hidden">No Results</p>
+            <table id="info-table" class="umls-app__table">
             <thead>
                 <tr>
                     <th>UI</th>
@@ -75,6 +76,7 @@
                 </tr>
             </tbody>
         </table>
+        </div>
     </div>
 </div>
     <script src="assets/js/mrrank-data.js"></script>


### PR DESCRIPTION
## Summary
- wrap results in a `results-inner` div
- remove padding/margins on inner result elements
- standardize padding on results container

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686eac1308b08327b73036186418ef19