### PR TITLE
Style tweaks for headings

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -210,23 +210,22 @@ pre {
   width: 100%;
 }
 
-.concept-summary {
-  margin: 0;
-  padding: 0;
-  border: 1px solid #ddd;
-  border-radius: 4px;
-  background: #fff;
-}
-.concept-summary h2 {
-  margin-top: 0;
-  font-size: 1.2em;
-}
-
 #results-heading {
   margin: 0;
   padding: 0;
   text-align: left;
   width: 100%;
+  padding-top: 0.5rem;
+}
+
+.concept-summary {
+  margin: 0;
+  padding: 0;
+}
+.concept-summary h2 {
+  margin-top: 0;
+  font-size: 1.2em;
+  padding-top: 0.5rem;
 }
 
 #search-summary {


### PR DESCRIPTION
## Summary
- update `#results-heading` and `.concept-summary` styles
- remove box appearance from concept summary
- add spacing above report headings

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686eb14f6b6883279709713ce935dee4