### PR TITLE
Fix results heading visibility

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -130,11 +130,6 @@ async function renderSearchResults(data, returnIdType) {
   const infoTableBody = document.querySelector("#info-table tbody");
   const tableHead = document.querySelector("#info-table thead");
   const resultsHeading = document.getElementById("results-heading");
-
-  if (resultsHeading) {
-    resultsHeading.textContent = "";
-    resultsHeading.classList.add("hidden");
-  }
   const infoTable = document.getElementById("info-table");
   const noResultsMessage = document.getElementById("no-results-message");
 
@@ -265,8 +260,7 @@ async function searchUMLS(options = {}) {
   const recentRequestContainer = document.getElementById("recent-request-output");
   const tableHead = document.querySelector("#info-table thead");
   if (resultsHeading) {
-    resultsHeading.textContent = "";
-    resultsHeading.classList.add("hidden");
+    resultsHeading.classList.remove("hidden");
   }
   const infoTable = document.getElementById("info-table");
   const noResultsMessage = document.getElementById("no-results-message");


### PR DESCRIPTION
## Summary
- keep heading visible when showing search results

## Testing
- `npm test` *(fails: could not find package.json)*
- `node -c assets/js/script.js`

------
https://chatgpt.com/codex/tasks/task_e_686eafb066f48327a5289bb8a416c12a