### PR TITLE
Default vocab selection

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -505,6 +505,10 @@ function navigateToUmlsUrl(url, key) {
           const cb = document.querySelector(`#vocab-container input[value="${v}"]`);
           if (cb) cb.checked = true;
         });
+      } else {
+        document.querySelectorAll("#vocab-container input").forEach((cb) => {
+          cb.checked = true;
+        });
       }
       if (typeof window.updateVocabVisibility === "function") {
         window.updateVocabVisibility();
@@ -1481,6 +1485,10 @@ window.addEventListener("DOMContentLoaded", function () {
       sabs.split(",").forEach(v => {
         const cb = document.querySelector(`#vocab-container input[value="${v}"]`);
         if (cb) cb.checked = true;
+      });
+    } else {
+      document.querySelectorAll("#vocab-container input").forEach(cb => {
+        cb.checked = true;
       });
     }
     updateVocabVisibility();

--- a/umls-api-interactive.html
+++ b/umls-api-interactive.html
@@ -27,11 +27,11 @@
 
             <div id="vocab-container" class="umls-app__vocab-container hidden">
                 <label class="umls-app__label">Vocabularies:</label>
-                <label><input type="checkbox" value="CPT"> CPT</label>
-                <label><input type="checkbox" value="ICD10CM"> ICD10CM</label>
-                <label><input type="checkbox" value="MSH"> MSH</label>
-                <label><input type="checkbox" value="RXNORM"> RXNORM</label>
-                <label><input type="checkbox" value="SNOMEDCT_US"> SNOMEDCT_US</label>
+                <label><input type="checkbox" value="CPT" checked> CPT</label>
+                <label><input type="checkbox" value="ICD10CM" checked> ICD10CM</label>
+                <label><input type="checkbox" value="MSH" checked> MSH</label>
+                <label><input type="checkbox" value="RXNORM" checked> RXNORM</label>
+                <label><input type="checkbox" value="SNOMEDCT_US" checked> SNOMEDCT_US</label>
             </div>
 
             <button class="umls-app__button" onclick="searchUMLS()">Search</button>


### PR DESCRIPTION
## Summary
- check all vocabularies on page load
- ensure default selections remain when no `sabs` query parameter is present

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_686eb2ba69f883278655cd6f23fe84d6