### PR TITLE
Fix returnIdType for sourceUi searches

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -1450,12 +1450,15 @@ window.addEventListener("DOMContentLoaded", function () {
     const apiKey = params.get("apiKey");
     const searchString = params.get("string");
     let returnIdType = params.get("returnIdType") || hashParams.returnIdType;
-    if (!returnIdType) {
-      returnIdType = "concept";
-    }
     const sabs = params.get("sabs") || hashParams.sabs;
     const inputType = params.get("inputType") || hashParams.inputType;
     const searchType = params.get("searchType") || hashParams.searchType;
+    if (inputType === "sourceUi" && searchType === "exact") {
+      returnIdType = "concept";
+    }
+    if (!returnIdType) {
+      returnIdType = "concept";
+    }
     let detail = params.get("detail") || hashParams.detail;
     if (detail === "concept") detail = "";
     let cui = params.get("cui") || hashParams.cui;


### PR DESCRIPTION
## Summary
- ensure returnIdType defaults to `concept` when searching by source UI

## Testing
- `git log -1 --stat`


------
https://chatgpt.com/codex/tasks/task_e_686eb38bd8a48327bb6caebfd3e4beb7