### PR TITLE
Fix heading for AUI results

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -107,9 +107,15 @@ function renderConceptSummary(concept, detailType = "") {
   const name = concept.name || modalCurrentData.name || "";
   const ui = concept.ui || modalCurrentData.ui || "";
   let headerText = name ? `${name} (${ui})` : ui;
-  const source = concept.rootSource || modalCurrentData.sab;
-  if (source) {
-    headerText += ` - ${source} code`;
+
+  const isAtom = modalCurrentData.returnIdType === "aui";
+  if (isAtom) {
+    headerText += " Atom";
+  } else {
+    const source = concept.rootSource || modalCurrentData.sab;
+    if (source) {
+      headerText += ` - ${source} code`;
+    }
   }
   if (detailType) {
     headerText += ` ${detailType}`;


### PR DESCRIPTION
## Summary
- improve summary header logic so that Atom requests do not show SAB/`code` info

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686fbf290e0483279c8677e30516128c