### PR TITLE
Fix NONE value display in reports

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -659,7 +659,7 @@ async function fetchConceptDetails(cui, detailType = "", options = {}) {
 
       Object.keys(detailObj).forEach(key => {
         const value = detailObj[key];
-        if (typeof value === "string" && value.toUpperCase() === "NONE") return;
+        // Previously we skipped fields with a value of "NONE". Now we include them
         const tr = document.createElement("tr");
         const tdKey = document.createElement("td");
         tdKey.textContent = key;
@@ -712,7 +712,7 @@ async function fetchConceptDetails(cui, detailType = "", options = {}) {
       Object.keys(detailObj).forEach(key => {
         if (/atomcount/i.test(key)) return;
         const value = detailObj[key];
-        if (typeof value === "string" && value.toUpperCase() === "NONE") return;
+        // Previously we skipped fields with a value of "NONE". Now we include them
         const tr = document.createElement("tr");
         const tdKey = document.createElement("td");
         tdKey.textContent = key;
@@ -1064,7 +1064,7 @@ async function fetchAuiDetails(aui, detailType = "", options = {}) {
     if (detailObj && typeof detailObj === "object") {
       Object.keys(detailObj).forEach(key => {
         const value = detailObj[key];
-        if (typeof value === "string" && value.toUpperCase() === "NONE") return;
+        // Previously we skipped fields with a value of "NONE". Now we include them
         const tr = document.createElement("tr");
         const tdKey = document.createElement("td");
         tdKey.textContent = key;
@@ -1184,10 +1184,7 @@ async function fetchRelatedDetail(apiUrl, relatedType, rootSource, options = {})
     Object.keys(detailObj).forEach((key) => {
       const value = detailObj[key];
 
-      // Exclude NONE values
-      if (typeof value === "string" && value.toUpperCase() === "NONE") {
-        return;
-      }
+      // Fields with a value of "NONE" are now displayed
 
       const tr = document.createElement("tr");
       const tdKey = document.createElement("td");
@@ -1392,7 +1389,7 @@ async function fetchSemanticType(tui, options = {}) {
     if (detailObj && typeof detailObj === "object") {
       Object.keys(detailObj).forEach(key => {
         const value = detailObj[key];
-        if (typeof value === "string" && value.toUpperCase() === "NONE") return;
+        // Previously we skipped fields with a value of "NONE". Now we include them
         const tr = document.createElement("tr");
         const tdKey = document.createElement("td");
         tdKey.textContent = key;


### PR DESCRIPTION
## Summary
- remove filtering of fields with value `NONE`
- update comments to reflect that `NONE` values are now displayed

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_686fbff6fcb0832789ca643c52976ed1