### PR TITLE
Add doc link mapping for CUI/AUI/TUI/source/search

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -371,8 +371,21 @@ function updateDocLink(urlObject) {
     }
   }
 
+  const lowerParts = pathParts.map(p => p.toLowerCase());
+  if (lowerParts.includes("search")) {
+    docSection = "search";
+  } else if (pathParts.includes("CUI")) {
+    docSection = "concept";
+  } else if (pathParts.includes("AUI")) {
+    docSection = "atoms";
+  } else if (pathParts.includes("source")) {
+    docSection = "source-asserted-identifiers";
+  } else if (pathParts.includes("TUI") || pathParts.some(p => /^T\d{3}$/i.test(p))) {
+    docSection = "semantic-network";
+  }
+
   let docUrl = `https://documentation.uts.nlm.nih.gov/rest/${docSection}/index.html`;
-  if (anchorDocMap[last]) {
+  if (anchorDocMap[last] && anchorDocMap[last] === docSection) {
     docUrl += `#${last}`;
   }
 


### PR DESCRIPTION
## Summary
- update `updateDocLink` logic to recognize key path parts
- link to the correct documentation section for search, CUI, AUI, TUI and source paths

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686fc035b394832791b63827f3e6466e