### PR TITLE
Fix URL wrapping

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -243,6 +243,12 @@ pre {
   border-radius: 4px;
 }
 
+/* Allow long URLs in the recent request section to wrap */
+.umls-app__recent-request pre {
+  white-space: pre-wrap;
+  overflow-wrap: anywhere;
+}
+
 
 
 /* in your styles.css */


### PR DESCRIPTION
## Summary
- wrap long URLs in the recent request section so they don't overflow

## Testing
- `npm test` *(fails: package.json missing)*
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68716d67c29c8327bb825e059bd73735