### PR TITLE
Fix heading detail labeling

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -134,7 +134,7 @@ function renderConceptSummary(concept, detailType = "") {
       headerText += ` - ${source} code`;
     }
   }
-  if (detailType) {
+  if (detailType && detailType !== "to" && detailType !== "from") {
     headerText += ` ${detailType}`;
   }
   header.textContent = headerText.trim();
@@ -703,9 +703,12 @@ async function fetchConceptDetails(cui, detailType = "", options = {}) {
         ? data
         : null;
 
+    if (detailObj && detailObj.name) {
+      modalCurrentData.name = detailObj.name;
+    }
     if (detailType) {
       renderConceptSummary({
-        name: modalCurrentData.name || (detailObj && detailObj.name),
+        name: (detailObj && detailObj.name) || modalCurrentData.name,
         ui: cui,
         rootSource: modalCurrentData.sab || (detailObj && detailObj.rootSource)
       }, detailType);
@@ -1151,8 +1154,11 @@ async function fetchAuiDetails(aui, detailType = "", options = {}) {
         ? data
         : null;
 
+    if (detailObj && detailObj.name) {
+      modalCurrentData.name = detailObj.name;
+    }
     renderConceptSummary({
-      name: modalCurrentData.name || (detailObj && detailObj.name),
+      name: (detailObj && detailObj.name) || modalCurrentData.name,
       ui: aui,
       rootSource: modalCurrentData.sab || (detailObj && detailObj.rootSource)
     }, detailType);
@@ -1272,8 +1278,11 @@ async function fetchRelatedDetail(apiUrl, relatedType, rootSource, options = {})
         ? data
         : null;
 
+    if (detailObj && detailObj.name) {
+      modalCurrentData.name = detailObj.name;
+    }
     renderConceptSummary({
-      name: modalCurrentData.name || (detailObj && detailObj.name),
+      name: (detailObj && detailObj.name) || modalCurrentData.name,
       ui: modalCurrentData.ui,
       rootSource: modalCurrentData.sab || (detailObj && detailObj.rootSource)
     }, relatedType);


### PR DESCRIPTION
## Summary
- preserve API-provided names when showing detail results
- avoid showing `to` or `from` in result headings

## Testing
- `node --check assets/js/script.js` *(fails: SyntaxError)*

------
https://chatgpt.com/codex/tasks/task_e_68716f3bf5188327803921ee6d82ebbf