### PR TITLE
Fix NoCode check for trailing slashes

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -107,7 +107,9 @@ function extractCui(concept) {
 function isNoCode(id) {
   if (typeof id !== "string") return false;
   const clean = id.trim();
-  const lastPart = clean.split("/").pop().replace(/[?#].*$/, "");
+  const withoutQuery = clean.replace(/[?#].*$/, "");
+  const trimmed = withoutQuery.replace(/\/+$/, "");
+  const lastPart = trimmed.split("/").pop();
   return lastPart.toUpperCase() === "NOCODE";
 }
 


### PR DESCRIPTION
## Summary
- handle trailing slash cases in `isNoCode`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6871719578e8832784380decc92cce58