### PR TITLE
Fix NoCode check for trailing slashes

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -106,9 +106,8 @@ function extractCui(concept) {
 
 function isNoCode(id) {
   if (typeof id !== "string") return false;
-  const clean = id.trim();
-  const lastPart = clean.split("/").pop().replace(/[?#].*$/, "");
-  return lastPart.toUpperCase() === "NOCODE";
+  const cleaned = stripBaseUrl(id.trim());
+  return cleaned.toUpperCase() === "NOCODE";
 }
 
 function renderConceptSummary(concept, detailType = "") {
@@ -417,8 +416,10 @@ function updateDocLink(urlObject) {
 
 function stripBaseUrl(fullUrl) {
   if (!fullUrl) return "";
-  const parts = fullUrl.split("/");
-  let last = parts.length ? parts[parts.length - 1] : fullUrl;
+  const withoutQuery = fullUrl.replace(/[?#].*$/, "");
+  const trimmed = withoutQuery.replace(/\/+$/, "");
+  const parts = trimmed.split("/");
+  let last = parts.length ? parts[parts.length - 1] : trimmed;
   if (last === "code" && parts.length > 1) {
     last = parts[parts.length - 2];
   }


### PR DESCRIPTION
## Summary
- handle trailing slash cases in `isNoCode`

## Testing
- `npm test` *(fails: could not find package.json)*

------
https://chatgpt.com/codex/tasks/task_e_6871719578e8832784380decc92cce58