### PR TITLE
Fix comma display in recent request URL

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -341,8 +341,10 @@ function colorizeUrl(urlObject) {
   let colorized = `<span style="color:blue">${base}</span>`;
   const params = [];
   for (let [key, value] of urlObject.searchParams.entries()) {
+    const encodedKey = encodeURIComponent(key);
+    const encodedValue = encodeURIComponent(value).replace(/%2C/g, ',');
     params.push(
-      `<span style="color:green">${encodeURIComponent(key)}</span>=<span style="color:red">${encodeURIComponent(value)}</span>`
+      `<span style="color:green">${encodedKey}</span>=<span style="color:red">${encodedValue}</span>`
     );
   }
   if (params.length > 0) {


### PR DESCRIPTION
## Summary
- fix `colorizeUrl` to keep commas visible in URL parameters

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68750ab93de48327b22c09b9d404a29d