### PR TITLE
Show code in results header for source endpoints

### DIFF
--- a/assets/js/script.js
+++ b/assets/js/script.js
@@ -122,8 +122,13 @@ function renderConceptSummary(concept, detailType = "") {
   summary.innerHTML = "";
   const header = document.createElement("h2");
   const name = concept.name || modalCurrentData.name || "";
-  const ui = concept.ui || modalCurrentData.ui || "";
-  let headerText = name ? `${name} (${ui})` : ui;
+  let identifier;
+  if (modalCurrentData.returnIdType === "code") {
+    identifier = stripBaseUrl(modalCurrentData.uri) || modalCurrentData.ui || concept.ui || "";
+  } else {
+    identifier = concept.ui || modalCurrentData.ui || "";
+  }
+  let headerText = name ? `${name} (${identifier})` : identifier;
 
   const isAtom = modalCurrentData.returnIdType === "aui";
   if (isAtom) {


### PR DESCRIPTION
## Summary
- display the requested code in the concept summary header when viewing source endpoints

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_68750b9c0d808327a157e992ab9ec230