### PR TITLE
Style intro paragraph with border

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -69,6 +69,16 @@ pre {
   box-sizing: border-box;
 }
 
+/* Intro paragraphs at the top */
+.umls-app > p {
+  padding: 20px;
+  margin: 0 0 1rem 0;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
 .umls-app__form {
   max-width: 400px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- add border styling for intro paragraphs at the top of the page

## Testing
- `node test/url-utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68793eae5b908327accddf91f9af28c0