### PR TITLE
Add padding around Raw Data summary

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -209,6 +209,10 @@ pre {
   padding: 5px 0;
   width: 100%;
 }
+/* Add spacing around the Raw Data summary text */
+.raw-data-details > summary {
+  padding: 4px 0;
+}
 
 #results-heading {
   margin: 0;


### PR DESCRIPTION
## Summary
- tweak CSS to add vertical padding around the Raw Data section

## Testing
- `node --test test/url-utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_68793eda3e8083278eb8f7bcd026e3d4