### PR TITLE
Add border styling for intro paragraphs

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -79,6 +79,16 @@ pre {
   box-sizing: border-box;
 }
 
+/* Container for the intro paragraphs */
+.umls-app__container {
+  padding: 20px;
+  margin: 0 0 1rem 0;
+  border: 1px solid #ddd;
+  border-radius: 4px;
+  width: 100%;
+  box-sizing: border-box;
+}
+
 .umls-app__form {
   max-width: 400px;
   margin: 0 auto;


### PR DESCRIPTION
## Summary
- style `.umls-app__container` so the introductory paragraphs are enclosed in a bordered box

## Testing
- `node test/url-utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6879407cdae8832785d9db0a3b82d4df