### PR TITLE
Fix intro paragraph styling

### DIFF
--- a/assets/css/local-uts.css
+++ b/assets/css/local-uts.css
@@ -70,7 +70,7 @@ pre {
 }
 
 /* Intro paragraphs at the top */
-.umls-app > p {
+.umls-app__container:not(.two-column) p {
   padding: 20px;
   margin: 0 0 1rem 0;
   border: 1px solid #ddd;


### PR DESCRIPTION
## Summary
- scope intro paragraph styles to `.umls-app__container:not(.two-column) p`
- remove unused container rule that incorrectly styled all containers

## Testing
- `node test/url-utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6879407cdae8832785d9db0a3b82d4df