### PR TITLE
Fix code ancestors URL persistence

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -45,6 +45,7 @@ export async function searchUMLS(options = {}) {
   const { skipPushState = false, useCache = false, release } = options;
   searchRelease = release || "current";
   const apiKey = document.getElementById("api-key").value.trim();
+  if (apiKey) localStorage.setItem('apiKey', apiKey);
   const searchString = document.getElementById("query").value.trim();
   const returnIdType = document.getElementById("return-id-type").value;
   const selectedVocabularies =
@@ -158,6 +159,7 @@ export async function fetchConceptDetails(cui, detailType = "", options = {}) {
   scrollRecentRequestIntoView();
   const { skipPushState = false } = options;
   const apiKey = document.getElementById("api-key").value.trim();
+  if (apiKey) localStorage.setItem('apiKey', apiKey);
   const returnIdType = modalCurrentData.returnIdType ||
     document.getElementById("return-id-type").value;
   const resultsContainer = document.getElementById("output");
@@ -659,6 +661,7 @@ export async function fetchAuiDetails(aui, detailType = "", options = {}) {
   scrollRecentRequestIntoView();
   const { skipPushState = false } = options;
   const apiKey = document.getElementById("api-key").value.trim();
+  if (apiKey) localStorage.setItem('apiKey', apiKey);
   if (!apiKey) {
     alert("Please enter an API key first.");
     return;
@@ -944,6 +947,7 @@ export async function fetchRelatedDetail(apiUrl, relatedType, rootSource, option
   scrollRecentRequestIntoView();
   const { skipPushState = false } = options;
   const apiKey = document.getElementById("api-key").value.trim();
+  if (apiKey) localStorage.setItem('apiKey', apiKey);
   if (!apiKey) {
     alert("Please enter an API key first.");
     return;
@@ -1117,6 +1121,7 @@ export async function fetchRelatedDetail(apiUrl, relatedType, rootSource, option
 export async function fetchCuisForCode(code, sab) {
   scrollRecentRequestIntoView();
   const apiKey = document.getElementById("api-key").value.trim();
+  if (apiKey) localStorage.setItem('apiKey', apiKey);
   if (!apiKey) {
     alert("Please enter an API key first.");
     return;
@@ -1227,6 +1232,7 @@ export async function fetchSemanticType(tui, options = {}) {
   const { skipPushState = false, release = DEFAULT_SEMANTIC_NETWORK_RELEASE } = options;
   modalCurrentData.returnIdType = "semanticType";
   const apiKey = document.getElementById("api-key").value.trim();
+  if (apiKey) localStorage.setItem('apiKey', apiKey);
   if (!apiKey) {
     alert("Please enter an API key first.");
     return;

--- a/assets/js/init.js
+++ b/assets/js/init.js
@@ -21,7 +21,8 @@ window.addEventListener('DOMContentLoaded', function () {
   function applyUrlParams(fromPopState = false) {
     const params = new URLSearchParams(window.location.search);
     const hashParams = parseHash();
-    const apiKey = params.get('apiKey');
+    const storedKey = localStorage.getItem('apiKey');
+    const apiKey = params.get('apiKey') || storedKey;
     const searchString = params.get('string');
     let returnIdType = params.get('returnIdType') || hashParams.returnIdType;
     const sabs = params.get('sabs') || hashParams.sabs;
@@ -50,6 +51,7 @@ window.addEventListener('DOMContentLoaded', function () {
 
     if (apiKey) {
       document.getElementById('api-key').value = apiKey;
+      localStorage.setItem('apiKey', apiKey);
     }
     if (searchString) {
       document.getElementById('query').value = searchString;


### PR DESCRIPTION
## Summary
- store the API key in `localStorage`
- restore API key on page load so URLs with code details work after refresh

## Testing
- `node test/url-utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_688252061f108327a99cceb5e26ae1c7