### PR TITLE
Display API key error on 403

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -31,7 +31,7 @@ function collapseRawDataDetails() {
 }
 
 function checkForbidden(response) {
-  if (response && response.status === 403) {
+  if (response && (response.status === 403 || response.status === 401)) {
     displayApiKeyError('Invalid API key. Please enter a valid API key.');
   } else {
     hideApiKeyError();

--- a/test/api-key-error.test.mjs
+++ b/test/api-key-error.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { displayApiKeyError, hideApiKeyError } from '../assets/js/dom.js';
+
+const el = {
+  textContent: '',
+  classList: {
+    _classes: new Set(['hidden']),
+    add(c) { this._classes.add(c); },
+    remove(c) { this._classes.delete(c); },
+    contains(c) { return this._classes.has(c); }
+  }
+};
+
+global.document = {
+  getElementById(id) {
+    return id === 'api-key-error' ? el : null;
+  }
+};
+
+test('displayApiKeyError shows message and removes hidden', () => {
+  displayApiKeyError('bad key');
+  assert.equal(el.textContent, 'bad key');
+  assert.ok(!el.classList.contains('hidden'));
+});
+
+test('hideApiKeyError clears message and adds hidden', () => {
+  hideApiKeyError();
+  assert.equal(el.textContent, '');
+  assert.ok(el.classList.contains('hidden'));
+});


### PR DESCRIPTION
## Summary
- surface a helpful error message when API responses are unauthorized
- add unit tests for API key error DOM helpers

## Testing
- `node test/api-key-error.test.mjs`
- `node test/url-utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6883b840c640832794874163bd053fbe