### PR TITLE
Display API key error on 403

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -31,7 +31,7 @@ function collapseRawDataDetails() {
 }
 
 function checkForbidden(response) {
-  if (response && response.status === 403) {
+  if (response && (response.status === 403 || response.status === 401)) {
     displayApiKeyError('Invalid API key. Please enter a valid API key.');
   } else {
     hideApiKeyError();

--- a/test/api-key-error.test.mjs
+++ b/test/api-key-error.test.mjs
@@ -1,0 +1,31 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { displayApiKeyError, hideApiKeyError } from '../assets/js/dom.js';
+
+const el = {
+  textContent: '',
+  classList: {
+    _classes: new Set(['hidden']),
+    add(c) { this._classes.add(c); },
+    remove(c) { this._classes.delete(c); },
+    contains(c) { return this._classes.has(c); }
+  }
+};
+
+global.document = {
+  getElementById(id) {
+    return id === 'api-key-error' ? el : null;
+  }
+};
+
+test('displayApiKeyError shows message and removes hidden', () => {
+  displayApiKeyError('bad key');
+  assert.equal(el.textContent, 'bad key');
+  assert.ok(!el.classList.contains('hidden'));
+});
+
+test('hideApiKeyError clears message and adds hidden', () => {
+  hideApiKeyError();
+  assert.equal(el.textContent, '');
+  assert.ok(el.classList.contains('hidden'));
+});

--- a/umls-api-interactive.html
+++ b/umls-api-interactive.html
@@ -49,10 +49,10 @@
                 <label for="api-key" class="umls-app__label">API Key</label>
                 <input type="password" id="api-key" class="umls-app__input" placeholder="Enter your UMLS API key"
                     value="API_KEY_HERE" required>
+                <p id="api-key-error" class="api-key-error hidden"></p>
                 <p>Get your API key from <a href="https://uts.nlm.nih.gov/uts/profile" target="_blank">your UTS
                         profile</a>.
                 </p>
-                <p id="api-key-error" class="api-key-error hidden"></p>
             </div>
         </div>
         <div class="umls-app__recent-request" id="recent-request">


### PR DESCRIPTION
## Summary
- surface a helpful error message when API responses are unauthorized
- add unit tests for API key error DOM helpers
- place the API key error message immediately below the input

## Testing
- `node test/api-key-error.test.mjs`
- `node test/url-utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_6883b840c640832794874163bd053fbe