### PR TITLE
Fix AUI details view missing infoTable

### DIFF
--- a/assets/js/api.js
+++ b/assets/js/api.js
@@ -671,6 +671,8 @@ export async function fetchAuiDetails(aui, detailType = "", options = {}) {
   const infoTableBody = document.querySelector("#info-table tbody");
   const recentRequestContainer = document.getElementById("recent-request-output");
   const tableHead = document.querySelector("#info-table thead");
+  const infoTable = document.getElementById("info-table");
+  if (infoTable) infoTable.style.display = "";
 
   const resultsHeading = document.getElementById("results-heading");
   if (resultsHeading) {


### PR DESCRIPTION
## Summary
- Ensure `fetchAuiDetails` shows the info table and references the table element.
- Prevent `ReferenceError: infoTable is not defined` when navigating to AUI details.

## Testing
- `node --test test/api-key-error.test.mjs test/url-utils.test.mjs`

------
https://chatgpt.com/codex/tasks/task_e_689e2b91233c8327b86e89923e3b6952